### PR TITLE
Nullify assistant 'content' when text is empty and there are tool calls

### DIFF
--- a/src/convert-to-requesty-chat-messages.ts
+++ b/src/convert-to-requesty-chat-messages.ts
@@ -149,7 +149,7 @@ export function convertToRequestyChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: !text && toolCalls.length > 0 ? undefined : text,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           cache_control: getCacheControl(providerMetadata),
         });


### PR DESCRIPTION
This fixes the issue on Requesty:
`anthropic: send request: messages: text content blocks must be non-empty`