### PR TITLE
Added requesty provider metadata with cache usage

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -38,3 +38,14 @@ export type RequestySharedSettings = RequestyProviderOptions & {
    */
   models?: string[];
 };
+
+export type RequestyUsage = {
+  cachingTokens?: number;
+  cachedTokens?: number;
+};
+
+export type RequestyProviderMetadata = {
+  requesty: {
+    usage?: RequestyUsage;
+  };
+};


### PR DESCRIPTION
* added `providerMetadata` when usage is available

Example:
```
 {"providerMetadata":{"requesty":{"usage":{"cachedTokens":23134,"cachingTokens":1321}}}
```