### PR TITLE
fix: not parsing tool call

### DIFF
--- a/src/requesty-chat-language-model.ts
+++ b/src/requesty-chat-language-model.ts
@@ -231,19 +231,11 @@ export class RequestyChatLanguageModel implements LanguageModelV2 {
     // Add tool calls
     if (choice.message.tool_calls) {
       for (const toolCall of choice.message.tool_calls) {
-        let parsedArguments: unknown;
-        try {
-          parsedArguments = JSON.parse(toolCall.function.arguments);
-        } catch {
-          // If parsing fails, use the raw string
-          parsedArguments = toolCall.function.arguments;
-        }
-
         content.push({
           type: 'tool-call',
           toolCallId: toolCall.id ?? generateId(),
           toolName: toolCall.function.name,
-          input: parsedArguments as any, // AI SDK expects unknown/any for tool input
+          input: toolCall.function.arguments as any, // AI SDK expects unknown/any for tool input
         });
       }
     }


### PR DESCRIPTION
The ai-sdk expects string

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in tool call parsing by removing the JSON parsing logic and passing the raw string arguments directly to the AI SDK, which expects string format rather than parsed objects.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/requesty-chat-language-model.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->