### PR TITLE
fix: disable filename hashing to resolve type definition errors

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig([
         format: ['cjs', 'esm'],
         dts: true,
         sourcemap: true,
+        hash: false,
     },
     {
         entry: ['src/internal/index.ts'],
@@ -13,5 +14,6 @@ export default defineConfig([
         format: ['cjs', 'esm'],
         dts: true,
         sourcemap: true,
+        hash: false,
     },
 ])


### PR DESCRIPTION
# fix: disable filename hashing in tsdown to fix type resolution

## Description

**The Problem**
Currently, the build configuration uses the default behavior of `tsdown`, which generates hashed filenames for chunks (e.g., `dist/index-F6sdE3i3.d.ts`).

**The Consequence**
Standard TypeScript environments (specifically Node.js without bundlers) fail to resolve the type definitions because `package.json` points to a static entry point, but the actual files on disk have dynamic hashes. This leads to the error:
> `Could not find a declaration file for module... implicitly has an 'any' type.`

## The Fix
I explicitly added `hash: false` to `tsdown.config.ts`. This ensures the output files have stable filenames (e.g., `index.d.ts`), matching what the package entry points expect.

## Verification
1. Built locally (`pnpm build`).
2. Verified that `dist/` now contains clean `.d.ts` files without hashes.
3. Linked to a consumer project via `pnpm link` and confirmed the TypeScript error is resolved.

## Related Issue
Closes #34 

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes TypeScript type definition resolution errors by disabling filename hashing in the `tsdown` build configuration. Previously, the build generated files with dynamic hashes (like `index-F6sdE3i3.d.ts`) which prevented Node.js environments from resolving type definitions that referenced static filenames. By setting `hash: false` in two build configurations, the output files now have stable, predictable names that match the package entry points.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tsdown.config.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->