### PR TITLE
using `reasoning_content` instead of `reasoning`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@requesty/ai-sdk",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "license": "Apache-2.0",
     "sideEffects": false,
     "main": "./dist/index.js",

--- a/src/messages/handle-assistant-message.test.ts
+++ b/src/messages/handle-assistant-message.test.ts
@@ -88,7 +88,7 @@ describe('assistant messages', () => {
             {
                 role: 'assistant',
                 content: null,
-                reasoning: 'Let me think about this...',
+                reasoning_content: 'Let me think about this...',
             },
         ],
         [
@@ -109,7 +109,7 @@ describe('assistant messages', () => {
             {
                 role: 'assistant',
                 content: null,
-                reasoning: 'First, then...',
+                reasoning_content: 'First, then...',
             },
         ],
         [
@@ -130,7 +130,7 @@ describe('assistant messages', () => {
             {
                 role: 'assistant',
                 content: 'Here is my answer.',
-                reasoning: 'Thinking...',
+                reasoning_content: 'Thinking...',
             },
         ],
         [
@@ -259,7 +259,7 @@ describe('assistant messages', () => {
             {
                 role: 'assistant',
                 content: 'Looking that up...',
-                reasoning: 'I need to search for this.',
+                reasoning_content: 'I need to search for this.',
                 tool_calls: [
                     {
                         id: 'call_999',

--- a/src/messages/handle-assistant-message.ts
+++ b/src/messages/handle-assistant-message.ts
@@ -25,7 +25,7 @@ export function handleAssistantMessage(
         .map((c) => c.text)
         .join('')
     if (reasoning.length > 0) {
-        assistantMessage.reasoning = reasoning
+        assistantMessage.reasoning_content = reasoning
     }
 
     const contentToolCalls = message.content.filter(

--- a/src/requesty-chat-language-model.ts
+++ b/src/requesty-chat-language-model.ts
@@ -234,10 +234,10 @@ export class RequestyChatLanguageModel implements LanguageModelV3 {
         }
 
         // Add reasoning content if present
-        if (choice.message.reasoning) {
+        if (choice.message.reasoning_content) {
             content.push({
                 type: 'reasoning',
-                text: choice.message.reasoning,
+                text: choice.message.reasoning_content,
             })
         }
 
@@ -347,7 +347,7 @@ const RequestyNonStreamChatCompletionResponseSchema = z.object({
             message: z.object({
                 role: z.string(),
                 content: z.string().nullable().optional(),
-                reasoning: z.string().optional(),
+                reasoning_content: z.string().optional(),
                 reasoning_signature: z.string().optional(),
                 tool_calls: z
                     .array(
@@ -395,7 +395,7 @@ export const RequestyStreamChatCompletionChunkSchema = z.object({
                     .object({
                         content: z.string().nullable().optional(),
                         reasoning_signature: z.string().nullable().optional(),
-                        reasoning: z.string().nullable().optional(),
+                        reasoning_content: z.string().nullable().optional(),
                         tool_calls: RequestyStreamChatCompletionToolSchema,
                     })
                     .optional(),

--- a/src/stream/index.test.ts
+++ b/src/stream/index.test.ts
@@ -375,7 +375,7 @@ describe('stream', () => {
                         choices: [
                             {
                                 delta: {
-                                    reasoning: 'Let me think...',
+                                    reasoning_content: 'Let me think...',
                                 },
                             },
                         ],
@@ -433,7 +433,7 @@ describe('stream', () => {
                         choices: [
                             {
                                 delta: {
-                                    reasoning: ' more reasoning',
+                                    reasoning_content: ' more reasoning',
                                 },
                             },
                         ],

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -155,7 +155,7 @@ export const createTransform = ({
             })
         }
 
-        if (delta.reasoning) {
+        if (delta.reasoning_content) {
             let id = reasoningId.get()
             if (!id) {
                 id = generateId()
@@ -170,7 +170,7 @@ export const createTransform = ({
             controller.enqueue({
                 id,
                 type: 'reasoning-delta',
-                delta: delta.reasoning,
+                delta: delta.reasoning_content,
             })
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,7 @@ export interface RequestyChatMessage {
     content: string | null | RequestUserObjectContentParts
     tool_call_id?: string
     tool_calls?: RequestyToolCall[]
-    reasoning?: string
+    reasoning_content?: string
     reasoning_signature?: string
 }
 


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR renames the `reasoning` field to `reasoning_content` throughout the codebase to maintain consistency with API naming conventions. The change affects the type definition, message handling logic, response parsing, and corresponding test cases.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/types.ts` |
| 2 | `src/messages/handle-assistant-message.ts` |
| 3 | `src/requesty-chat-language-model.ts` |
| 4 | `src/messages/handle-assistant-message.test.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->