### PR TITLE
feat: add cost field to providerMetadata usage

### DIFF
--- a/src/integration/chat.test.ts
+++ b/src/integration/chat.test.ts
@@ -61,6 +61,11 @@ describe('Requesty Integration - Chat', () => {
                 inputTokens: 10,
                 outputTokens: 9,
                 totalTokens: 19,
+                raw: {
+                    prompt_tokens: 10,
+                    completion_tokens: 9,
+                    total_tokens: 19,
+                },
             })
         })
 

--- a/src/requesty-chat-language-model.ts
+++ b/src/requesty-chat-language-model.ts
@@ -205,20 +205,27 @@ export class RequestyChatLanguageModel implements LanguageModelV2 {
             throw new Error('No choice in response')
         }
 
-        const providerMetadata = response.usage?.prompt_tokens_details
-            ? ({
-                  requesty: {
-                      usage: {
-                          cachingTokens:
-                              response.usage.prompt_tokens_details
-                                  .caching_tokens ?? 0,
-                          cachedTokens:
-                              response.usage.prompt_tokens_details
-                                  .cached_tokens ?? 0,
+        const hasPromptTokensDetails = response.usage?.prompt_tokens_details
+        const hasCost = response.usage?.cost != null
+
+        const providerMetadata =
+            hasPromptTokensDetails || hasCost
+                ? ({
+                      requesty: {
+                          usage: {
+                              cachingTokens:
+                                  response.usage?.prompt_tokens_details
+                                      ?.caching_tokens ?? 0,
+                              cachedTokens:
+                                  response.usage?.prompt_tokens_details
+                                      ?.cached_tokens ?? 0,
+                              ...(hasCost
+                                  ? { cost: response.usage!.cost }
+                                  : {}),
+                          },
                       },
-                  },
-              } satisfies SharedV2ProviderMetadata)
-            : undefined
+                  } satisfies SharedV2ProviderMetadata)
+                : undefined
 
         // Convert to content format
         const content: Array<LanguageModelV2Content> = []
@@ -428,6 +435,7 @@ export const RequestyStreamChatCompletionChunkSchema = z.object({
                     cached_tokens: z.number().optional(),
                 })
                 .optional(),
+            cost: z.number().optional(),
         })
         .optional(),
     error: z.any().optional(),

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -36,6 +36,7 @@ function handleUsageChunk(
 
     const requestyUsage: Partial<RequestyUsage> = {
         cachingTokens: usage.prompt_tokens_details?.caching_tokens ?? 0,
+        ...(usage.cost != null ? { cost: usage.cost } : {}),
     }
 
     return [modelUsage, requestyUsage]
@@ -307,14 +308,17 @@ export const createFlush = ({
         const providerMetadata: SharedV2ProviderMetadata = {
             requesty: {
                 usage:
-                    currentRequestyUsage.cachedTokens &&
-                    currentRequestyUsage.cachingTokens
+                    currentRequestyUsage.cachedTokens ||
+                    currentRequestyUsage.cachingTokens ||
+                    currentRequestyUsage.cost != null
                         ? currentRequestyUsage
                         : {},
             },
         }
 
-        const hasProviderMetadata = providerMetadata.requesty?.usage
+        const hasProviderMetadata =
+            providerMetadata.requesty?.usage &&
+            Object.keys(providerMetadata.requesty.usage).length > 0
 
         const currentFinishReason = finishReason.get()
         const currentUsage = usage.get()

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export type RequestySharedSettings = RequestyProviderOptions & {
 export type RequestyUsage = {
     cachingTokens?: number
     cachedTokens?: number
+    cost?: number
 }
 
 export type RequestyProviderMetadata = {


### PR DESCRIPTION
## Summary

Adds the `cost` field from `response.usage.cost` into `providerMetadata.requesty.usage`, alongside existing `cachingTokens` and `cachedTokens`.

## Changes

- **`src/types.ts`** — Added `cost?: number` to `RequestyUsage` type
- **`src/requesty-chat-language-model.ts`** — Include `cost` from `response.usage.cost` in `doGenerate` providerMetadata; added `cost` to `RequestyStreamChatCompletionChunkSchema` usage Zod schema
- **`src/stream/index.ts`** — Extract `cost` in `handleUsageChunk`; forward `cost` in `createFlush` providerMetadata

## Usage

The `cost` is now available in `providerMetadata.requesty.usage.cost` for both `doGenerate` and streaming responses:

```ts
const result = await generateText({
  model: requesty('...'),
  prompt: '...',
})

const cost = result.providerMetadata?.requesty?.usage?.cost
```