### PR TITLE
fix: use reasoningId instead of activeId for reasoning stream parts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@requesty/ai-sdk",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "license": "Apache-2.0",
     "sideEffects": false,
     "main": "./dist/index.js",

--- a/src/stream/index.test.ts
+++ b/src/stream/index.test.ts
@@ -392,7 +392,7 @@ describe('stream', () => {
                 controller,
             )
 
-            expect(activeId.set).toHaveBeenCalled()
+            expect(reasoningId.set).toHaveBeenCalled()
             expect(enqueuedParts).toContainEqual(
                 expect.objectContaining({
                     type: 'reasoning-start',

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -159,7 +159,7 @@ export const createTransform = ({
             let id = reasoningId.get()
             if (!id) {
                 id = generateId()
-                activeId.set(id)
+                reasoningId.set(id)
 
                 controller.enqueue({
                     type: 'reasoning-start',


### PR DESCRIPTION
## Bug

When handling `delta.reasoning_content` in the streaming transform (`src/stream/index.ts`), the code set the generated ID on `activeId` (the **text** ID holder) instead of `reasoningId` (the **reasoning** ID holder).

This caused `reasoningId.get()` to always return `undefined`, so every reasoning SSE chunk emitted a new `reasoning-start` + `reasoning-delta` pair, producing dozens of separate `{ type: "reasoning" }` content parts instead of one continuous reasoning part.

It also prevented `reasoning-end` from being emitted during flush (since `reasoningId.get()` was always `undefined`).

## Fix

Changed `activeId.set(id)` → `reasoningId.set(id)` in `src/stream/index.ts`.

## Comparison

Other providers (e.g. `@ai-sdk/openai-compatible`, `@ai-sdk/openai`) correctly use their reasoning-specific ID holder when emitting `reasoning-start`.

Fixes #42